### PR TITLE
Small improvements to Github Action workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
+        if: github.event_name != 'pull_request'
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/example-publisher
 


### PR DESCRIPTION
This PR improves a bit the Github Action workflow.
It uses docker login images rather than specifying the commands along with docker meta for fetching current ref.

It will also push only on a merge to main/tag.