### PR TITLE
Fix/update loop gone

### DIFF
--- a/example_publisher/provider.py
+++ b/example_publisher/provider.py
@@ -13,12 +13,14 @@ class Price:
 
 
 class Provider(ABC):
+    _update_loop_task = None
+
     @abstractmethod
     def upd_products(self, product_symbols: List[Symbol]):
         ...
 
     def start(self) -> None:
-        asyncio.create_task(self._update_loop())
+        self._update_loop_task = asyncio.create_task(self._update_loop())
 
     @abstractmethod
     async def _update_loop(self):

--- a/example_publisher/providers/pyth_replicator.py
+++ b/example_publisher/providers/pyth_replicator.py
@@ -31,6 +31,7 @@ class PythReplicator(Provider):
         self._prices: Dict[
             str, Tuple[float | None, float | None, UnixTimestamp | None]
         ] = {}
+        self._update_accounts_task: asyncio.Task | None = None
 
     async def _update_loop(self) -> None:
         self._ws = self._client.create_watch_session()
@@ -41,7 +42,7 @@ class PythReplicator(Provider):
             self._config.program_key, await self._client.get_all_accounts()
         )
 
-        asyncio.create_task(self._update_accounts_loop())
+        self._update_accounts_task = asyncio.create_task(self._update_accounts_loop())
 
         while True:
             update = await self._ws.next_update()

--- a/example_publisher/publisher.py
+++ b/example_publisher/publisher.py
@@ -49,7 +49,9 @@ class Publisher:
     async def start(self):
         await self.pythd.connect()
 
-        self._product_update_task = asyncio.create_task(self._start_product_update_loop())
+        self._product_update_task = asyncio.create_task(
+            self._start_product_update_loop()
+        )
 
     async def _start_product_update_loop(self):
         await self._upd_products()

--- a/example_publisher/publisher.py
+++ b/example_publisher/publisher.py
@@ -27,6 +27,7 @@ class Product:
 class Publisher:
     def __init__(self, config: Config) -> None:
         self.config: Config = config
+        self._product_update_task: asyncio.Task | None = None
 
         if not getattr(self.config, self.config.provider_engine):
             raise ValueError(f"Missing {self.config.provider_engine} config")
@@ -48,7 +49,7 @@ class Publisher:
     async def start(self):
         await self.pythd.connect()
 
-        asyncio.create_task(self._start_product_update_loop())
+        self._product_update_task = asyncio.create_task(self._start_product_update_loop())
 
     async def _start_product_update_loop(self):
         await self._upd_products()

--- a/example_publisher/pythd.py
+++ b/example_publisher/pythd.py
@@ -70,7 +70,9 @@ class Pythd:
 
     def _notify_price_sched(self, subscription: int) -> None:
         log.debug("notify_price_sched RPC call received", subscription=subscription)
-        task = asyncio.get_event_loop().create_task(self.on_notify_price_sched(subscription))
+        task = asyncio.get_event_loop().create_task(
+            self.on_notify_price_sched(subscription)
+        )
         self._notify_price_sched_tasks.add(task)
         task.add_done_callback(lambda: self._notify_price_sched_tasks.remove(task))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "example-publisher"
-version = "1.0.1"
+version = "1.0.2"
 description = ""
 authors = []
 license = "Apache-2"


### PR DESCRIPTION
From #19

https://docs.python.org/3/library/asyncio-task.html#creating-tasks

"Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done."

Building off the example i end up with a publisher that suddenly dies. It looks like some places violate the documentation recommendations.