### PR TITLE
fix: handle task callback correctly

### DIFF
--- a/example_publisher/providers/coin_gecko.py
+++ b/example_publisher/providers/coin_gecko.py
@@ -30,7 +30,7 @@ class CoinGecko(Provider):
                 new_prices[id] = self._prices.get(id, None)
             else:
                 raise ValueError(
-                    f"{coin_gecko_product.symbol} not found in available products"
+                    f"{coin_gecko_product.symbol} not found in available products"  # noqa: E713
                 )
 
         self._prices = new_prices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "example-publisher"
-version = "1.0.2"
+version = "1.0.3"
 description = ""
 authors = []
 license = "Apache-2"


### PR DESCRIPTION
The existing code was crashing on calling the callback lambda for a completed task because it takes `task` as parameter and our lambda had no input. This change just passes discard that takes an element as an argument. Discard is chosen over remove to ensure it won't raise error (although it shouldn't happen).

I tested it and it works fine now.