### PR TITLE
allow duplicate symbols for artificial scaling

### DIFF
--- a/example_publisher/publisher.py
+++ b/example_publisher/publisher.py
@@ -87,7 +87,9 @@ class Publisher:
         }
         log.debug("fetched product accounts from Pythd", products=pythd_products)
 
-        old_products_by_generic_symbol = {product.generic_symbol: product for product in self.products}
+        old_products_by_generic_symbol = {
+            product.generic_symbol: product for product in self.products
+        }
 
         self.products = []
 

--- a/example_publisher/publisher.py
+++ b/example_publisher/publisher.py
@@ -17,6 +17,7 @@ TRADING = "trading"
 
 @define
 class Product:
+    generic_symbol: str
     symbol: str
     product_account: str
     price_account: str
@@ -81,26 +82,27 @@ class Publisher:
     async def _upd_products(self):
         log.debug("fetching product accounts from Pythd")
         pythd_products = {
-            product.metadata.symbol: product
+            product.metadata.generic_symbol: product
             for product in await self.pythd.all_products()
         }
         log.debug("fetched product accounts from Pythd", products=pythd_products)
 
-        old_products_by_symbol = {product.symbol: product for product in self.products}
+        old_products_by_generic_symbol = {product.generic_symbol: product for product in self.products}
 
         self.products = []
 
-        for symbol, product in pythd_products.items():
+        for generic_symbol, product in pythd_products.items():
             if not product.prices:
                 continue
 
             subscription_id = None
-            if old_product := old_products_by_symbol.get(symbol):
+            if old_product := old_products_by_generic_symbol.get(generic_symbol):
                 subscription_id = old_product.subscription_id
 
             self.products.append(
                 Product(
-                    symbol,
+                    generic_symbol,
+                    product.metadata.symbol,
                     product.account,
                     product.prices[0].account,
                     product.prices[0].exponent,

--- a/example_publisher/pythd.py
+++ b/example_publisher/pythd.py
@@ -24,6 +24,7 @@ class Price(DataClassJsonMixin):
 @dataclass
 class Metadata(DataClassJsonMixin):
     symbol: str
+    generic_symbol: str
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "example-publisher"
-version = "1.1.1"
+version = "1.1.2"
 description = ""
 authors = []
 license = "Apache-2"


### PR DESCRIPTION
use generic_symbol instead of symbol as a unique identifier